### PR TITLE
Fixed error in declaration of overload_cast

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -498,7 +498,7 @@ PYBIND11_MODULE(_bindings, m) {
           }
         )
         .def("weight",
-          overload_cast<double, const GenEvent, const size_t&>(&GenEvent::weight),
+          overload_cast<double, const GenEvent, const const unsigned long&>(&GenEvent::weight),
           "index"_a = 0)
         .def("weight",
           overload_cast<double, const GenEvent, const std::string&>(&GenEvent::weight),


### PR DESCRIPTION
Declaration in of argument in overload_cast different from header. MSVC was throwing errors.