### PR TITLE
Adds GenEvent.from_hepevt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ python_requires = >=3.6
 
 [options.extras_require]
 test =
+    numpy
     pytest
     pytest-cov
     graphviz

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -490,6 +490,11 @@ PYBIND11_MODULE(_core, m) {
              HepMC3::Print::listing(os, self, 2);
              return os.str();
            })
+
+      .def("from_hepevt", from_hepevt, "event_number"_a, "px"_a, "py"_a, "pz"_a, "en"_a,
+           "m"_a, "pid"_a, "status"_a, "parents"_a = py::none(),
+           "children"_a = py::none(), "vx"_a = py::none(), "vy"_a = py::none(),
+           "vz"_a = py::none(), "vt"_a = py::none())
       // clang-format off
       METH(clear, GenEvent)
       PROP(run_info, GenEvent)

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -264,10 +264,10 @@ inline std::ostream& repr(std::ostream& os, const HepMC3::GenEvent& x) {
   return os;
 }
 
-void from_hepevent(GenEvent& event, int event_number, py::array_t<float> momentum,
-                   py::array_t<float> mass, py::array_t<float> position,
-                   py::array_t<int> pid, py::array_t<int> parents,
-                   py::array_t<int> children, py::array_t<int> status);
+void from_hepevt(GenEvent& event, int event_number, py::array_t<double> momentum,
+                 py::array_t<double> mass, py::array_t<double> position,
+                 py::array_t<int> pid, py::array_t<int> status, py::object parents,
+                 py::object children);
 
 } // namespace HepMC3
 
@@ -285,7 +285,6 @@ PYBIND11_MODULE(_core, m) {
   //        GenEvent
   //        GenParticle
   //        GenVertex
-  //        fill_genevent_from_hepevt
   //        print_hepevt
   //        print_content
   //        print_listing

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -263,6 +263,12 @@ inline std::ostream& repr(std::ostream& os, const HepMC3::GenEvent& x) {
   repr(os, x.run_info()) << ")";
   return os;
 }
+
+void from_hepevent(GenEvent& event, int event_number, py::array_t<float> momentum,
+                   py::array_t<float> mass, py::array_t<float> position,
+                   py::array_t<int> pid, py::array_t<int> parents,
+                   py::array_t<int> children, py::array_t<int> status);
+
 } // namespace HepMC3
 
 PYBIND11_MODULE(_core, m) {
@@ -482,7 +488,6 @@ PYBIND11_MODULE(_core, m) {
                           METH_OL(remove_vertex, GenEvent, void, GenVertexPtr)
                               METH_OL(remove_particle, GenEvent, void, GenParticlePtr)
       .def("reserve", &GenEvent::reserve, "particles"_a, "vertices"_a = 0)
-          METH(clear, GenEvent)
       .def(py::self == py::self)
       .def("__repr__",
            [](GenEvent& self) {

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -66,8 +66,8 @@ bool operator!=(const GenParticle& a, const GenParticle& b) {
 
 // compares all real qualities of both particle sets,
 // but ignores the .id() fields and the particle order
-bool equal_particle_set(const std::vector<ConstGenParticlePtr>& a,
-                        const std::vector<ConstGenParticlePtr>& b) {
+bool equal_particle_sets(const std::vector<ConstGenParticlePtr>& a,
+                         const std::vector<ConstGenParticlePtr>& b) {
   if (a.size() != b.size()) return false;
   auto unmatched = b;
   for (auto&& ai : a) {
@@ -82,16 +82,16 @@ bool equal_particle_set(const std::vector<ConstGenParticlePtr>& a,
 // compares all real qualities of two vertices, but ignores the .id() field
 bool operator==(const GenVertex& a, const GenVertex& b) {
   return a.status() == b.status() && is_close(a.position(), b.position()) &&
-         equal_particle_set(a.particles_in(), b.particles_in()) &&
-         equal_particle_set(a.particles_out(), b.particles_out());
+         equal_particle_sets(a.particles_in(), b.particles_in()) &&
+         equal_particle_sets(a.particles_out(), b.particles_out());
 }
 
 bool operator!=(const GenVertex& a, const GenVertex& b) { return !operator==(a, b); }
 
 // compares all real qualities of both vertex sets,
 // but ignores the .id() fields and the vertex order
-bool equal_vertex_set(const std::vector<ConstGenVertexPtr>& a,
-                      const std::vector<ConstGenVertexPtr>& b) {
+bool equal_vertex_sets(const std::vector<ConstGenVertexPtr>& a,
+                       const std::vector<ConstGenVertexPtr>& b) {
   if (a.size() != b.size()) return false;
   auto unmatched = b;
   for (auto&& ai : a) {
@@ -153,7 +153,7 @@ bool operator==(const GenEvent& a, const GenEvent& b) {
   }
 
   // if all vertices compare equal, then also all particles are equal
-  return equal_vertex_set(a.vertices(), b.vertices());
+  return equal_vertex_sets(a.vertices(), b.vertices());
 }
 
 bool operator!=(const GenEvent& a, const GenEvent& b) { return !operator==(a, b); }
@@ -264,10 +264,11 @@ inline std::ostream& repr(std::ostream& os, const HepMC3::GenEvent& x) {
   return os;
 }
 
-void from_hepevt(GenEvent& event, int event_number, py::array_t<double> momentum,
-                 py::array_t<double> mass, py::array_t<double> position,
-                 py::array_t<int> pid, py::array_t<int> status, py::object parents,
-                 py::object children);
+void from_hepevt(GenEvent& event, int event_number, py::array_t<double> px,
+                 py::array_t<double> py, py::array_t<double> pz, py::array_t<double> en,
+                 py::array_t<double> m, py::array_t<int> pid, py::array_t<int> status,
+                 py::object parents, py::object children, py::object vx, py::object vy,
+                 py::object vz, py::object vt);
 
 } // namespace HepMC3
 
@@ -557,6 +558,9 @@ PYBIND11_MODULE(_core, m) {
     HepMC3::Print::listing(os, event, precision);
     return os.str();
   });
+
+  FUNC(equal_particle_sets);
+  FUNC(equal_vertex_sets);
 
   register_io(m);
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -439,8 +439,6 @@ PYBIND11_MODULE(_core, m) {
            "run"_a, "momentum_unit"_a = Units::GEV, "length_unit"_a = Units::MM)
       .def(py::init<Units::MomentumUnit, Units::LengthUnit>(),
            "momentum_unit"_a = Units::GEV, "length_unit"_a = Units::MM)
-          PROP_RO_OL(particles, GenEvent, const std::vector<ConstGenParticlePtr>&)
-              PROP_RO_OL(vertices, GenEvent, const std::vector<ConstGenVertexPtr>&)
       .def_property("weights",
                     overload_cast<std::vector<double>&, GenEvent>(&GenEvent::weights),
                     [](GenEvent& self, py::sequence seq) {
@@ -468,9 +466,6 @@ PYBIND11_MODULE(_core, m) {
           "name"_a, "value"_a)
       .def_property_readonly("weight_names",
                              [](const GenEvent& self) { return self.weight_names(); })
-          PROP(run_info, GenEvent) PROP(event_number, GenEvent)
-              PROP_RO(momentum_unit, GenEvent) PROP_RO(length_unit, GenEvent)
-                  METH(set_units, GenEvent)
       .def_property("heavy_ion",
                     overload_cast<GenHeavyIonPtr, GenEvent>(&GenEvent::heavy_ion),
                     &GenEvent::set_heavy_ion)
@@ -480,13 +475,7 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "cross_section",
           overload_cast<GenCrossSectionPtr, GenEvent>(&GenEvent::cross_section),
-          &GenEvent::set_cross_section) METH(event_pos, GenEvent)
-          PROP_RO_OL(beams, GenEvent, std::vector<ConstGenParticlePtr>)
-              METH_OL(add_vertex, GenEvent, void, GenVertexPtr)
-                  METH_OL(add_particle, GenEvent, void, GenParticlePtr)
-                      METH(set_beam_particles, GenEvent)
-                          METH_OL(remove_vertex, GenEvent, void, GenVertexPtr)
-                              METH_OL(remove_particle, GenEvent, void, GenParticlePtr)
+          &GenEvent::set_cross_section)
       .def("reserve", &GenEvent::reserve, "particles"_a, "vertices"_a = 0)
       .def(py::self == py::self)
       .def("__repr__",
@@ -495,11 +484,30 @@ PYBIND11_MODULE(_core, m) {
              repr(os, self);
              return os.str();
            })
-      .def("__str__", [](GenEvent& self) {
-        std::ostringstream os;
-        HepMC3::Print::listing(os, self, 2);
-        return os.str();
-      });
+      .def("__str__",
+           [](GenEvent& self) {
+             std::ostringstream os;
+             HepMC3::Print::listing(os, self, 2);
+             return os.str();
+           })
+      // clang-format off
+      METH(clear, GenEvent)
+      PROP(run_info, GenEvent)
+      PROP(event_number, GenEvent)
+      PROP_RO(momentum_unit, GenEvent)
+      PROP_RO(length_unit, GenEvent)
+      METH(set_units, GenEvent)
+      METH(event_pos, GenEvent)
+      PROP_RO_OL(beams, GenEvent, std::vector<ConstGenParticlePtr>)
+      METH_OL(add_vertex, GenEvent, void, GenVertexPtr)
+      METH_OL(add_particle, GenEvent, void, GenParticlePtr)
+      METH(set_beam_particles, GenEvent)
+      METH_OL(remove_vertex, GenEvent, void, GenVertexPtr)
+      METH_OL(remove_particle, GenEvent, void, GenParticlePtr)
+      PROP_RO_OL(particles, GenEvent, const std::vector<ConstGenParticlePtr>&)
+      PROP_RO_OL(vertices, GenEvent, const std::vector<ConstGenVertexPtr>&)
+      // clang-format on
+      ;
 
   py::class_<GenParticle, GenParticlePtr>(m, "GenParticle")
       .def(py::init<const FourVector&, int, int>(),

--- a/src/from_hepevent.cpp
+++ b/src/from_hepevent.cpp
@@ -1,0 +1,112 @@
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
+#include "pybind.h"
+
+#include <unordered_map>
+#include <utility>
+
+template <>
+struct std::hash<std::pair<int, int>> {
+  std::size_t operator()(const std::pair<int, int>& p) const noexcept {
+    auto h1 = std::hash<int>{}(p.first);
+    auto h2 = std::hash<int>{}(p.second);
+    return h1 ^ (h2 << 1); // or use boost::hash_combine
+  }
+};
+
+bool normalize(int& m1, int& m2) {
+  // normalize mother range, see
+  // https://pythia.org/latest-manual/ParticleProperties.html
+  // m1 == m2 == 0 : no mothers
+  // m1 == m2 > 0 : elastic scattering
+  // m1 > 0, m2 == 0 : one mother
+  // m1 < m2, both > 0: interaction
+  // m2 < m1, both > 0: same, needs swapping
+
+  if (m1 > 0 && m2 > 0 && m2 < m1) std::swap(m1, m2);
+
+  if (m1 > 0 && m2 == 0) m2 = m1;
+
+  return m2 == 0;
+}
+
+namespace HepMC3 {
+
+void from_hepevent(GenEvent& event, int event_number, py::array_t<float> momentum,
+                   py::array_t<float> mass, py::array_t<float> position,
+                   py::array_t<int> pid, py::array_t<int> parents,
+                   py::array_t<int> children, py::array_t<int> status) {
+
+  namespace py = pybind11;
+
+  if (momentum.request().ndim != 2) throw std::runtime_error("p must be 2D");
+  if (position.request().ndim != 2) throw std::runtime_error("v must be 2D");
+  if (parents.request().ndim != 2) throw std::runtime_error("parent must be 2D");
+  if (children.request().ndim != 2) throw std::runtime_error("children must be 2D");
+  if (mass.request().ndim != 1) throw std::runtime_error("m must be 1D");
+  if (pid.request().ndim != 1) throw std::runtime_error("pid must be 1D");
+  if (status.request().ndim != 1) throw std::runtime_error("status must be 1D");
+
+  auto rp = momentum.unchecked<2>();
+  auto rm = mass.unchecked<1>();
+  auto rv = position.unchecked<2>();
+  auto rpid = pid.unchecked<1>();
+  auto rpar = parents.unchecked<2>();
+  auto rchi = children.unchecked<2>();
+  auto rsta = status.unchecked<1>();
+
+  const int n = rm.shape(0);
+  if (rp.shape(0) != n || rv.shape(0) != n || rpid.shape(0) != n ||
+      rpar.shape(0) != n || rchi.shape(0) != n || rsta.shape(0) != n)
+    throw std::runtime_error(
+        "p, m, v, pid, parents, children, status must have same length");
+
+  if (rp.shape(1) != 4) throw std::runtime_error("p must have shape (N, 4)");
+
+  if (rv.shape(1) != 4) throw std::runtime_error("v must have shape (N, 4)");
+
+  event.clear();
+  event.reserve(n);
+  event.set_event_number(event_number);
+
+  // first pass, only add unique vertices
+  // particles with same ancestor(s) have the same starting vertex
+  std::unordered_map<std::pair<int, int>, int> vmap;
+  for (int i = 0; i < n; ++i) {
+    auto p = new GenParticle(FourVector(rp(i, 0), rp(i, 1), rp(i, 2), rp(i, 3)),
+                             rpid(i), rsta(i));
+    p->set_generated_mass(rm(i));
+    event.add_particle(p);
+
+    // if particle has no mother, it is beam
+    bool is_beam = rpar(i, 0) == rpar(i, 1) == 0;
+
+    if (!is_beam) vmap.emplace(std::make_pair(rpar(i, 0), rpar(i, 1)), i);
+  }
+
+  auto& particles = event.particles();
+
+  for (const auto& vx : vmap) {
+
+    int m1 = vx.first.first;
+    int m2 = vx.first.second;
+    if (normalize(m1, m2)) continue;
+
+    const int i = vx.second;
+    auto v = new GenVertex(FourVector(rv(i, 0), rv(i, 1), rv(i, 2), rv(i, 3)));
+    event.add_vertex(v);
+
+    for (int k = m1; k <= m2; ++k) v->add_particle_in(particles[k]);
+
+    // add any daugthers
+    // normalize daugther range, same rules as for mothers
+    int d1 = rchi(m1, 0);
+    int d2 = rchi(m1, 1);
+    if (normalize(d1, d2)) continue;
+
+    for (int k = d1; k <= d2; ++k) v->add_particle_out(particles[k]);
+  }
+}
+
+} // namespace HepMC3

--- a/src/from_hepevt.cpp
+++ b/src/from_hepevt.cpp
@@ -110,7 +110,7 @@ void from_hepevt(GenEvent& event, int event_number, py::array_t<double> momentum
     auto v = new GenVertex(FourVector(rv(i, 0), rv(i, 1), rv(i, 2), rv(i, 3)));
     event.add_vertex(v);
 
-    for (int k = m1; k <= m2; ++k) v->add_particle_in(particles[k]);
+    for (int k = m1; k <= m2; ++k) v->add_particle_in(particles.at(k));
 
     // add any daugthers from mother
     // normalize daugther range, same rules as for mothers
@@ -118,7 +118,7 @@ void from_hepevt(GenEvent& event, int event_number, py::array_t<double> momentum
     int d2 = rchi(m1, 1);
     if (normalize(d1, d2)) continue;
 
-    for (int k = d1; k <= d2; ++k) v->add_particle_out(particles[k]);
+    for (int k = d1; k <= d2; ++k) v->add_particle_out(particles.at(k));
   }
 }
 

--- a/src/pybind.h
+++ b/src/pybind.h
@@ -1,7 +1,7 @@
 #ifndef PYHEPMC_PYBIND_HEADER
 #define PYHEPMC_PYBIND_HEADER
 
-// #include <pybind11/numpy.h>
+#include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,5 @@
 import pytest
 import pyhepmc as hep
-import re
 
 
 @pytest.fixture()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,41 +1,41 @@
 import pytest
 import pyhepmc as hep
+import re
 
 
 @pytest.fixture()
 def evt():
-    #
-    # In this example we will place the following event into HepMC "by hand"
-    #
-    #     name status pdg_id  parent Px       Py    Pz       Energy      Mass
-    #  1  !p+!    1   2212    0,0    0.000    0.000 7000.000 7000.000    0.938
-    #  2  !p+!    2   2212    0,0    0.000    0.000-7000.000 7000.000    0.938
-    # =========================================================================
-    #  3  !d!     3      1    1,1    0.750   -1.569   32.191   32.238    0.000
-    #  4  !u~!    4     -2    2,2   -3.047  -19.000  -54.629   57.920    0.000
-    #  5  !W-!    5    -24    3,4    1.517   -20.68  -20.605   85.925   80.799
-    #  6  !gamma! 6     22    3,4   -3.813    0.113   -1.833    4.233    0.000
-    #  7  !d!     7      1    5,5   -2.445   28.816    6.082   29.552    0.010
-    #  8  !u~!    8     -2    5,5    3.962  -49.498  -26.687   56.373    0.006
+    r"""
+    In this example we will generate the following event by hand
 
-    # now we build the graph, which will looks like
-    #                       p7                         #
-    # p1                   /                           #
-    #   \v1__p3      p5---v4                           #
-    #         \_v3_/       \                           #
-    #         /    \        p8                         #
-    #    v2__p4     \                                  #
-    #   /            p6                                #
-    # p2                                               #
-    #                                                  #
+        name status pdg_id  parent Px       Py     Pz       Energy      Mass
+     1  !p+!    1   2212    0,0    0.000    0.000  7000.000 7000.000    0.938
+     2  !p+!    2   2212    0,0    0.000    0.000 -7000.000 7000.000    0.938
+    =========================================================================
+     3  !d!     3      1    1,1    0.750   -1.569    32.191   32.238    0.000
+     4  !u~!    4     -2    2,2   -3.047  -19.000   -54.629   57.920    0.000
+     5  !W-!    5    -24    3,4    1.517   -20.68   -20.605   85.925   80.799
+     6  !gamma! 6     22    3,4   -3.813    0.113    -1.833    4.233    0.000
+     7  !d!     7      1    5,5   -2.445   28.816     6.082   29.552    0.010
+     8  !u~!    8     -2    5,5    3.962  -49.498   -26.687   56.373    0.006
 
-    #
-    # Finally, the event gets a weight.
-    #
+    The corresponding graph looks like this
+
+                           p7
+     p1                   /
+       \v1__p3      p5---v4
+             \_v3_/       \
+             /    \        p8
+        v2__p4     \
+       /            p6
+     p2
+
+    Finally, the event gets a weight.
+    """
     evt = hep.GenEvent(hep.Units.GEV, hep.Units.MM)
     evt.event_number = 1
 
-    #                         px      py       pz        e   pdgid status
+    #                     px   py   pz      e        pdgid status
     p1 = hep.GenParticle((0.0, 0.0, 7000.0, 7000.0), 2212, 1)
     p1.generated_mass = 0.938
     p2 = hep.GenParticle((0.0, 0.0, -7000.0, 7000.0), 2212, 2)
@@ -108,6 +108,79 @@ def test_GenEvent(evt):
     assert p3.momentum == (0.750, -1.569, 32.191, 32.238)
     assert p4.parents == [p2]
     assert p4.momentum == (-3.047, -19.0, -54.629, 57.920)
+
+
+@pytest.mark.parametrize("use_parent", (True, False))
+def test_GenEvent_from_hepevt(use_parent, evt):
+    status = [p.status for p in evt.particles]
+    pid = [p.pid for p in evt.particles]
+    px = [p.momentum[0] for p in evt.particles]
+    py = [p.momentum[1] for p in evt.particles]
+    pz = [p.momentum[2] for p in evt.particles]
+    en = [p.momentum[3] for p in evt.particles]
+    m = [p.generated_mass for p in evt.particles]
+    vx = vy = vz = vt = [0, 0, 1, 2, 3, 3, 4, 4]
+
+    assert len(m) == 8
+
+    #                           p7
+    #     p1                   /
+    #       \v1__p3      p5---v4
+    #             \_v3_/       \
+    #             /    \        p8
+    #        v2__p4     \
+    #       /            p6
+    #     p2
+
+    parents = [(0, 0), (0, 0), (1, 1), (2, 2), (3, 4), (3, 4), (5, 5), (5, 5)]
+    children = [(3, 0), (4, 0), (5, 6), (5, 6), (7, 8), (0, 0), (0, 0), (0, 0)]
+
+    ev = hep.GenEvent()
+    if use_parent:
+        ev.from_hepevt(
+            evt.event_number,
+            px,
+            py,
+            pz,
+            en,
+            m,
+            pid,
+            status,
+            parents,
+            None,
+            vx,
+            vy,
+            vz,
+            vt,
+        )
+    else:
+        ev.from_hepevt(
+            evt.event_number,
+            px,
+            py,
+            pz,
+            en,
+            m,
+            pid,
+            status,
+            None,
+            children,
+            vx,
+            vy,
+            vz,
+            vt,
+        )
+
+    # cannot be taken from HepEvt record, but is set for evt
+    ev.weights = [1.0]
+    ev.run_info = hep.GenRunInfo()
+    ev.run_info.weight_names = ["0"]
+
+    assert len(ev.particles) == len(evt.particles)
+    assert ev.particles == evt.particles
+    assert len(ev.vertices) == len(evt.vertices)
+    assert hep.equal_vertex_sets(ev.vertices, evt.vertices)
+    assert ev == evt
 
 
 def test_sequence_access():


### PR DESCRIPTION
This is the more flexible equivalent of `fill_genevent_from_hepevt` which used to be part of pyhepmc-ng but was removed in the switch to v2.0. It does not use the corresponding HepMC3 code, which is a mess and only works for an original HepEvt common block.