### PR TITLE
pythonic generated_mass

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -538,6 +538,18 @@ PYBIND11_MODULE(_core, m) {
              repr(os, self);
              return os.str();
            })
+      .def_property(
+          "generated_mass",
+          [](GenParticle& self) {
+            if (self.is_generated_mass_set()) return py::cast(self.generated_mass());
+            return static_cast<py::object>(py::none());
+          },
+          [](GenParticle& self, py::object value) {
+            if (value.is_none())
+              self.unset_generated_mass();
+            else
+              self.set_generated_mass(py::cast<double>(value));
+          })
       // clang-format off
       PROP_RO_OL(parent_event, GenParticle, const GenEvent*)
       PROP_RO(in_event, GenParticle)
@@ -552,9 +564,6 @@ PYBIND11_MODULE(_core, m) {
       PROP(pid, GenParticle)
       PROP(status, GenParticle)
       PROP(momentum, GenParticle)
-      PROP(generated_mass, GenParticle)
-      METH(is_generated_mass_set, GenParticle)
-      METH(unset_generated_mass, GenParticle)
       // clang-format on
       ;
 

--- a/src/pyhepmc/__init__.py
+++ b/src/pyhepmc/__init__.py
@@ -29,6 +29,21 @@ from ._io import (  # noqa
     pyhepmc_open as open,
 )
 from ._version import __version__  # noqa
+from ._deprecated import deprecated as _deprecated
+
+
+@_deprecated("use `GenParticle.generated_mass is not None`")
+def _genparticle_is_generated_mass_set(self):
+    return self.generated_mass is not None
+
+
+@_deprecated("use `GenParticle.generated_mass = None`")
+def _genparticle_unset_generated_mass(self):
+    self.generated_mass = None
+
+
+GenParticle.is_generated_mass_set = _genparticle_is_generated_mass_set
+GenParticle.unset_generated_mass = _genparticle_unset_generated_mass
 
 try:
     from .view import to_dot

--- a/src/pyhepmc/_deprecated.py
+++ b/src/pyhepmc/_deprecated.py
@@ -1,0 +1,20 @@
+import warnings
+from numpy import VisibleDeprecationWarning
+
+
+class deprecated:
+    def __init__(self, reason):
+        self._reason = reason
+
+    def __call__(self, func):
+        def decorated_func(*args, **kwargs):
+            warnings.warn(
+                f"{func.__name__} is deprecated: {self._reason}",
+                category=VisibleDeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        decorated_func.__name__ = func.__name__
+        decorated_func.__doc__ = "deprecated: " + self._reason
+        return decorated_func

--- a/src/pyhepmc/view.py
+++ b/src/pyhepmc/view.py
@@ -51,7 +51,10 @@ def to_dot(evt, style=None):
 
         tooltip = f"{pname} [PDGID: {int(p.pid)}]"
         tooltip += f"\n{p.momentum} GeV"
-        tooltip += f"\nm = {p.generated_mass:.4g} GeV"
+        if p.generated_mass is not None:
+            tooltip += f"\nm = {p.generated_mass:.4g} GeV"
+        else:
+            tooltip += "\nm = not specified"
         tooltip += f"\nstatus = {p.status}"
 
         try:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 import pytest
 import pyhepmc as hep
+import numpy as np
 
 
 @pytest.fixture()
@@ -111,6 +112,25 @@ def test_GenEvent(evt):
     assert p3.momentum == (0.750, -1.569, 32.191, 32.238)
     assert p4.parents == [p2]
     assert p4.momentum == (-3.047, -19.0, -54.629, 57.920)
+
+
+def test_GenEvent_generated_mass():
+    p = hep.GenParticle((1.0, 1.0, 1.0, 1.0), 2212, 1)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        assert p.is_generated_mass_set() is False
+    p.generated_mass = 2.3
+    with pytest.warns(np.VisibleDeprecationWarning):
+        assert p.is_generated_mass_set() is True
+    assert p.generated_mass == 2.3
+    with pytest.warns(np.VisibleDeprecationWarning):
+        p.unset_generated_mass()
+        assert p.is_generated_mass_set() is False
+    p.generated_mass = 2.3
+    with pytest.warns(np.VisibleDeprecationWarning):
+        assert p.is_generated_mass_set() is True
+    p.generated_mass = None
+    with pytest.warns(np.VisibleDeprecationWarning):
+        assert p.is_generated_mass_set() is False
 
 
 @pytest.mark.parametrize("use_parent", (True, False))


### PR DESCRIPTION
is_generated_mass_set and unset_generated_mass are now deprecated. generated_mass returns None if it is not set and to unset it, assign None.