### PR TITLE
improved version sourcing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,18 +1,17 @@
 include src/*.cpp
 include src/*.h
 include src/pyhepmc/*.py
-include tests/*.py
 recursive-include extern/HepMC3/include *.h
 recursive-include extern/HepMC3/src *.cc
 recursive-include extern/pybind11/include *.h
 include extern/pybind11/CMakeLists.txt
 include extern/pybind11/tools/*.cmake
 include extern/pybind11/LICENSE
-include extern/HepMC3/LICENSE
+include extern/HepMC3/LICENCE
 include cmake_ext.py
 include CMakeLists.txt
 include LICENSE
 include pyproject.toml
-include README.md
+include README.rst
 include setup.cfg
 include setup.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include extern/pybind11/include *.h
 include extern/pybind11/CMakeLists.txt
 include extern/pybind11/tools/*.cmake
 include extern/pybind11/LICENSE
+include extern/HepMC3/LICENSE
 include cmake_ext.py
 include CMakeLists.txt
 include LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=46.4",
-    "setuptools_scm[toml]>=3.4",
+    "setuptools_scm[toml]>=6.2",
     "cmake>=3.13"
 ]
 build-backend = "setuptools.build_meta"
@@ -18,6 +18,7 @@ addopts = "-q -ra --ff"
 testpaths = ["tests"]
 filterwarnings = [
     "error::DeprecationWarning",
+    "error::VisibleDeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ addopts = "-q -ra --ff"
 testpaths = ["tests"]
 filterwarnings = [
     "error::DeprecationWarning",
-    "error::VisibleDeprecationWarning",
+    "error::numpy.VisibleDeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pyhepmc
-# version = attr: pyhepmc._version.version
 author = Hans Dembinski
 author_email = hans.dembinski@gmail.com
 description = Pythonic interface to the HepMC3 C++ library.
@@ -9,6 +8,7 @@ long_description_content_type = text/markdown
 url = https://github.com/scikit-hep/pyhepmc
 project_urls =
     Documentation = https://github.com/scikit-hep/pyhepmc
+license_files = LICENSE, extern/pybind11/LICENSE, extern/HepMC3/LICENSE
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: BSD License

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,18 @@ from pathlib import Path
 from setuptools import setup
 import sys
 
-cwd = Path(__file__).parent
+cdir = Path(__file__).parent
 
-sys.path.append(str(cwd))
+version = {}
+with open(cdir / "src" / "pyhepmc" / "_version.py") as f:
+    exec(f.read(), version)
+
+sys.path.append(str(cdir))
 from cmake_ext import CMakeExtension, CMakeBuild  # noqa: E402
 
 setup(
     zip_safe=False,
+    version=version["version"],
     ext_modules=[CMakeExtension("pyhepmc._core")],
     cmdclass={"build_ext": CMakeBuild},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from setuptools import setup
 import sys
 
-cdir = Path(__file__).parent
+cdir = Path(__file__).parent.absolute()
 
 version = {}
 with open(cdir / "src" / "pyhepmc" / "_version.py") as f:

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,13 @@ import sys
 
 cdir = Path(__file__).parent.absolute()
 
-version = {}
-with open(cdir / "src" / "pyhepmc" / "_version.py") as f:
-    exec(f.read(), version)
-
 sys.path.append(str(cdir))
 from cmake_ext import CMakeExtension, CMakeBuild  # noqa: E402
 
 setup(
     zip_safe=False,
-    version=version["version"],
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     ext_modules=[CMakeExtension("pyhepmc._core")],
     cmdclass={"build_ext": CMakeBuild},
 )


### PR DESCRIPTION
Using `:attr:` to get the version from pyhepmc/_version.py does not work when the installation fails due to some compilation error, making pyhepmc unimportable. `:attr:` is supposed to not invoke the Python interpreter to get the version literal, but for some reason this is not working. I suppose this only works when the version is a literal in `__init__.py`, but it is a literal in `pyhepmc/_version.py`. Since we cannot get rid of `setup.py`, because we need this to declare the CMakeExtensions there, we can just as well safely pull the version by `exec`ing `_version.py` from there.