### PR TITLE
Associated particle

### DIFF
--- a/src/UnparsedAttribute.hpp
+++ b/src/UnparsedAttribute.hpp
@@ -1,0 +1,22 @@
+#ifndef PYHEPMC_UNPARSEDATTRIBUTE_HPP
+#define PYHEPMC_UNPARSEDATTRIBUTE_HPP
+
+#include "pointer.hpp"
+#include "pybind.hpp"
+#include <cstdint>
+
+namespace HepMC3 {
+
+py::object unparsed_attribute_to_python(AttributePtr& unparsed, py::object pytype);
+
+struct UnparsedAttribute {
+  AttributePtr& parent_;
+
+  py::object astype(py::object pytype) {
+    return unparsed_attribute_to_python(parent_, pytype);
+  }
+};
+
+} // namespace HepMC3
+
+#endif

--- a/src/attribute_conversion.cpp
+++ b/src/attribute_conversion.cpp
@@ -93,6 +93,7 @@ py::object unparsed_attribute_to_python(AttributePtr& unparsed, py::object pytyp
   auto int_type = builtins.attr("int");
   auto float_type = builtins.attr("float");
   auto str_type = builtins.attr("str");
+  auto list_type = builtins.attr("list");
   py::module_ pyhepmc = py::module_::import("pyhepmc");
   auto particle_type = pyhepmc.attr("GenParticle");
   auto pdfinfo_type = pyhepmc.attr("GenPdfInfo");
@@ -101,9 +102,9 @@ py::object unparsed_attribute_to_python(AttributePtr& unparsed, py::object pytyp
   auto heprup_type = pyhepmc.attr("HEPRUPAttribute");
   auto hepeup_type = pyhepmc.attr("HEPEUPAttribute");
   py::module_ typing = py::module_::import("typing");
-  auto get_args = typing.attr("get_args");
-  auto get_origin = typing.attr("get_origin");
-  auto list1_type = builtins.attr("list");
+  // typing.get_origin and typing.get_args are only available in Python-3.8+
+  auto get_origin = pyhepmc.attr("_get_origin");
+  auto get_args = pyhepmc.attr("_get_args");
   auto list2_type = typing.attr("List");
 
   // Convert the internal attribute as well as the Python return value;
@@ -113,11 +114,10 @@ py::object unparsed_attribute_to_python(AttributePtr& unparsed, py::object pytyp
   py::object result;
 
   // handle lists first
-  if ((pytype.is(list1_type) || pytype.is(list2_type)))
+  if ((pytype.is(list_type) || pytype.is(list2_type)))
     throw py::type_error("cannot convert UnparsedAttribute to untyped list");
 
-  py::object origin = get_origin(pytype);
-  if (origin.is(list1_type) || origin.is(list2_type)) {
+  if (get_origin(pytype).is(list_type)) {
     py::object subtype = get_args(pytype)[py::int_(0)];
     if (!(convert<VectorIntAttribute>(unparsed, subtype, int_type, result) ||
           convert<VectorDoubleAttribute>(unparsed, subtype, float_type, result) ||

--- a/src/attribute_conversion.cpp
+++ b/src/attribute_conversion.cpp
@@ -34,6 +34,7 @@ py::object attribute_to_python(AttributePtr a) {
     if (auto x = std::dynamic_pointer_cast<AttributeType>(a)) result = py::cast(x);
   });
 
+  // AssociatedParticle derives from IntAttribute, so skip cast below if match found
   if (auto x = std::dynamic_pointer_cast<AssociatedParticle>(a))
     result = py::cast(x->associated());
 

--- a/src/attribute_conversion.cpp
+++ b/src/attribute_conversion.cpp
@@ -1,3 +1,5 @@
+#include "HepMC3/AssociatedParticle.h"
+#include "HepMC3/GenParticle_fwd.h"
 #include "pointer.hpp"
 #include "pybind.hpp"
 #include <HepMC3/Attribute.h>
@@ -9,6 +11,8 @@
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/list.hpp>
 #include <boost/mp11/utility.hpp>
+#include <memory>
+#include <pybind11/pytypes.h>
 #include <stdexcept>
 
 namespace HepMC3 {
@@ -30,8 +34,10 @@ py::object attribute_to_python(AttributePtr a) {
     if (auto x = std::dynamic_pointer_cast<AttributeType>(a)) result = py::cast(x);
   });
 
-  if (!result) {
+  if (auto x = std::dynamic_pointer_cast<AssociatedParticle>(a))
+    result = py::cast(x->associated());
 
+  if (!result) {
     using RawTypes =
         mp_list<IntAttribute, LongAttribute, DoubleAttribute, FloatAttribute,
                 StringAttribute, CharAttribute, LongLongAttribute, LongDoubleAttribute,
@@ -69,6 +75,9 @@ AttributePtr attribute_from_python(py::object obj) {
     result = py::cast<HEPRUPAttributePtr>(obj);
   } else if (py::isinstance<HEPEUPAttribute>(obj)) {
     result = py::cast<HEPEUPAttributePtr>(obj);
+  } else if (py::isinstance<GenParticle>(obj)) {
+    auto p = py::cast<GenParticlePtr>(obj);
+    result = std::make_shared<AssociatedParticle>(p);
   }
 
   if (!result) {

--- a/src/attribute_conversion.cpp
+++ b/src/attribute_conversion.cpp
@@ -116,7 +116,8 @@ py::object unparsed_attribute_to_python(AttributePtr& unparsed, py::object pytyp
   if ((pytype.is(list1_type) || pytype.is(list2_type)))
     throw py::type_error("cannot convert UnparsedAttribute to untyped list");
 
-  if (get_origin(pytype).is(list1_type) || get_origin(pytype).is(list2_type)) {
+  py::object origin = get_origin(pytype);
+  if (origin.is(list1_type) || origin.is(list2_type)) {
     py::object args = get_args(pytype);
     py::object subtype = args[py::int_(0)];
     if (!(convert<VectorIntAttribute>(unparsed, subtype, int_type, result) ||

--- a/src/attribute_conversion.cpp
+++ b/src/attribute_conversion.cpp
@@ -118,8 +118,7 @@ py::object unparsed_attribute_to_python(AttributePtr& unparsed, py::object pytyp
 
   py::object origin = get_origin(pytype);
   if (origin.is(list1_type) || origin.is(list2_type)) {
-    py::object args = get_args(pytype);
-    py::object subtype = args[py::int_(0)];
+    py::object subtype = get_args(pytype)[py::int_(0)];
     if (!(convert<VectorIntAttribute>(unparsed, subtype, int_type, result) ||
           convert<VectorDoubleAttribute>(unparsed, subtype, float_type, result) ||
           convert<VectorStringAttribute>(unparsed, subtype, str_type, result))) {

--- a/src/attributes_view.cpp
+++ b/src/attributes_view.cpp
@@ -19,6 +19,7 @@ MEMBER_ACCESSOR(MA1, HepMC3::GenEvent, m_attributes,
                 HepMC3::AttributesView::AttributeMap)
 
 namespace HepMC3 {
+
 py::object AttributesView::Iter::next() {
   while (it_ != end_) {
     auto& amap2 = it_->second;

--- a/src/attributes_view.hpp
+++ b/src/attributes_view.hpp
@@ -60,7 +60,7 @@ struct RunInfoAttributesView {
   iterator end();
 };
 
-py::object attribute_to_python(AttributePtr a);
+py::object attribute_to_python(AttributePtr& a);
 AttributePtr attribute_from_python(py::object obj);
 
 } // namespace HepMC3

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -476,7 +476,6 @@ PYBIND11_MODULE(_core, m) {
           DOC(attributes))
       .def("reserve", &GenEvent::reserve, "particles"_a, "vertices"_a = 0,
            DOC(GenEvent.reserve))
-      .def(py::self == py::self)
       .def("__str__",
            [](GenEvent& self) {
              std::ostringstream os;
@@ -487,6 +486,7 @@ PYBIND11_MODULE(_core, m) {
            "m"_a, "pid"_a, "status"_a, "parents"_a = py::none(),
            "children"_a = py::none(), "vx"_a = py::none(), "vy"_a = py::none(),
            "vz"_a = py::none(), "vt"_a = py::none(), DOC(GenEvent.from_hepevt))
+      .def(py::self == py::self)
       // clang-format off
       REPR(GenEvent)
       METH(clear, GenEvent)
@@ -564,7 +564,7 @@ PYBIND11_MODULE(_core, m) {
           DOC(GenVertex.attributes))
       .def(py::self == py::self)
       // clang-format off
-      REPR(GenParticle)
+      REPR(GenVertex)
       PROP_RO_OL(parent_event, GenVertex, const GenEvent*)
       PROP_RO(in_event, GenVertex)
       PROP_RO(id, GenVertex)

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,3 +1,4 @@
+#include "HepMC3/AssociatedParticle.h"
 #include "attributes_view.hpp"
 #include "pointer.hpp"
 #include "pybind.hpp"

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,6 +1,7 @@
 #include "attributes_view.hpp"
 #include "pointer.hpp"
 #include "pybind.hpp"
+#include "repr.hpp"
 #include <HepMC3/Attribute.h>
 #include <HepMC3/FourVector.h>
 #include <HepMC3/GenCrossSection.h>
@@ -30,235 +31,26 @@
 
 void register_io(py::module& m);
 
-template <class Iterator, class Streamer>
-std::ostream& ostream_range(std::ostream& os, Iterator begin, Iterator end,
-                            Streamer streamer, const char bracket_left = '[',
-                            const char bracket_right = ']') {
-  os << bracket_left;
-  bool first = true;
-  for (; begin != end; ++begin) {
-    if (first) {
-      first = false;
-    } else {
-      os << ", ";
-    }
-    streamer(os, begin);
-  }
-  os << bracket_right;
-  return os;
+template <class T>
+py::str repr(const T& t) {
+  std::ostringstream os;
+  repr_ostream(os, t);
+  return py::cast(os.str());
 }
 
 namespace HepMC3 {
 
-template <class T>
-bool operator!=(const T& a, const T& b) {
-  return !operator==(a, b);
-}
+bool operator==(const GenParticle& a, const GenParticle& b);
+bool operator==(const GenVertex& a, const GenVertex& b);
+bool operator==(const GenRunInfo& a, const GenRunInfo& b);
+bool operator==(const GenRunInfo::ToolInfo& a, const GenRunInfo::ToolInfo& b);
+bool operator==(const GenEvent& a, const GenEvent& b);
+bool operator==(const GenHeavyIon& a, const GenHeavyIon& b);
 
-// equality comparions used by unit tests
-bool is_close(const FourVector& a, const FourVector& b, double rel_eps = 1e-7) {
-  auto is_close = [rel_eps](double a, double b) { return std::abs(a - b) < rel_eps; };
-  return is_close(a.x(), b.x()) && is_close(a.y(), b.y()) && is_close(a.z(), b.z()) &&
-         is_close(a.t(), b.t());
-}
-
-// compares all real qualities of two particles, but ignores the .id() field
-bool operator==(const GenParticle& a, const GenParticle& b) {
-  return a.pid() == b.pid() && a.status() == b.status() &&
-         is_close(a.momentum(), b.momentum());
-}
-
-// compares all real qualities of both particle sets,
-// but ignores the .id() fields and the particle order
 bool equal_particle_sets(const std::vector<ConstGenParticlePtr>& a,
-                         const std::vector<ConstGenParticlePtr>& b) {
-  if (a.size() != b.size()) return false;
-  auto unmatched = b;
-  for (auto&& ai : a) {
-    auto it = std::find_if(unmatched.begin(), unmatched.end(),
-                           [ai](ConstGenParticlePtr x) { return *ai == *x; });
-    if (it == unmatched.end()) return false;
-    unmatched.erase(it);
-  }
-  return unmatched.empty();
-}
-
-// compares all real qualities of two vertices, but ignores the .id() field
-bool operator==(const GenVertex& a, const GenVertex& b) {
-  return a.status() == b.status() && is_close(a.position(), b.position()) &&
-         equal_particle_sets(a.particles_in(), b.particles_in()) &&
-         equal_particle_sets(a.particles_out(), b.particles_out());
-}
-
-// compares all real qualities of both vertex sets,
-// but ignores the .id() fields and the vertex order
+                         const std::vector<ConstGenParticlePtr>& b);
 bool equal_vertex_sets(const std::vector<ConstGenVertexPtr>& a,
-                       const std::vector<ConstGenVertexPtr>& b) {
-  if (a.size() != b.size()) return false;
-  auto unmatched = b;
-  for (auto&& ai : a) {
-    auto it = std::find_if(unmatched.begin(), unmatched.end(),
-                           [ai](ConstGenVertexPtr x) { return *ai == *x; });
-    if (it == unmatched.end()) return false;
-    unmatched.erase(it);
-  }
-  return unmatched.empty();
-}
-
-bool operator==(const GenRunInfo::ToolInfo& a, const GenRunInfo::ToolInfo& b) {
-  return a.name == b.name && a.version == b.version && a.description == b.description;
-}
-
-bool operator==(const GenRunInfo& a, const GenRunInfo& b) {
-  const auto a_attr = a.attributes();
-  const auto b_attr = b.attributes();
-  return a.tools().size() == b.tools().size() &&
-         a.weight_names().size() == b.weight_names().size() &&
-         a_attr.size() == b_attr.size() &&
-         std::equal(a.tools().begin(), a.tools().end(), b.tools().begin()) &&
-         std::equal(a.weight_names().begin(), a.weight_names().end(),
-                    b.weight_names().begin()) &&
-         std::equal(a_attr.begin(), a_attr.end(), b_attr.begin(),
-                    [](const std::pair<std::string, AttributePtr>& a,
-                       const std::pair<std::string, AttributePtr>& b) {
-                      if (a.first != b.first) return false;
-                      if (bool(a.second) != bool(b.second)) return false;
-                      if (!a.second) return true;
-                      std::string sa, sb;
-                      a.second->to_string(sa);
-                      b.second->to_string(sb);
-                      return sa == sb;
-                    });
-}
-
-bool operator==(const GenEvent& a, const GenEvent& b) {
-  // incomplete:
-  // missing comparison of GenHeavyIon, GenPdfInfo, GenCrossSection
-
-  if (a.event_number() != b.event_number() || a.momentum_unit() != b.momentum_unit() ||
-      a.length_unit() != b.length_unit())
-    return false;
-
-  // run_info may be missing
-  if (a.run_info() && b.run_info()) {
-    if (!(*a.run_info() == *b.run_info())) return false;
-  } else if (!a.run_info() && b.run_info()) {
-    if (*b.run_info() != GenRunInfo()) return false;
-  } else if (a.run_info() && !b.run_info()) {
-    if (*a.run_info() != GenRunInfo()) return false;
-  }
-
-  // if all vertices compare equal, then also all particles are equal
-  return equal_vertex_sets(a.vertices(), b.vertices());
-}
-
-bool operator==(const GenHeavyIon& a, const GenHeavyIon& b) {
-  return a.Ncoll_hard == b.Ncoll_hard && a.Npart_proj == b.Npart_proj &&
-         a.Npart_targ == b.Npart_targ && a.Ncoll == b.Ncoll &&
-         a.N_Nwounded_collisions == b.N_Nwounded_collisions &&
-         a.Nwounded_N_collisions == b.Nwounded_N_collisions &&
-         a.Nwounded_Nwounded_collisions == b.Nwounded_Nwounded_collisions &&
-         a.impact_parameter == b.impact_parameter &&
-         a.event_plane_angle == b.event_plane_angle &&
-         a.sigma_inel_NN == b.sigma_inel_NN && a.centrality == b.centrality &&
-         a.user_cent_estimate == b.user_cent_estimate;
-}
-
-template <class T>
-std::ostream& repr(std::ostream& os, const std::shared_ptr<T>& x) {
-  if (x)
-    repr(os, *x.get());
-  else
-    os << "None";
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const std::string& s) {
-  os << "'" << s << "'";
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::Attribute& a) {
-  std::string s;
-  a.to_string(s);
-  os << s;
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::GenRunInfo::ToolInfo& x) {
-  os << "ToolInfo(name=";
-  repr(os, x.name) << ", version=";
-  repr(os, x.version) << ", description=";
-  repr(os, x.description) << ")";
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::FourVector& x) {
-  const int saved = os.precision();
-  os.precision(3);
-  os << "FourVector(" << x.x() << ", " << x.y() << ", " << x.z() << ", " << x.t()
-     << ")";
-  os.precision(saved);
-  return os;
-}
-
-template <class T, class A>
-std::ostream& repr(std::ostream& os, const std::vector<T, A>& v) {
-  return ostream_range(
-      os, v.begin(), v.end(),
-      [](std::ostream& os, typename std::vector<T, A>::const_iterator it) {
-        repr(os, *it);
-      });
-}
-
-template <class K, class V, class... Ts>
-std::ostream& repr(std::ostream& os, const std::map<K, V, Ts...>& m) {
-  return ostream_range(
-      os, m.begin(), m.end(),
-      [](std::ostream& os, typename std::map<K, V, Ts...>::const_iterator it) {
-        os << it->first << ": ";
-        repr(os, it->second);
-      },
-      '{', '}');
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::GenRunInfo& x) {
-  os << "GenRunInfo(tools=";
-  repr(os, x.tools()) << ", weight_names=";
-  repr(os, x.weight_names()) << ", attributes=";
-  repr(os, x.attributes()) << ")";
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::GenParticle& x) {
-  os << "GenParticle(";
-  repr(os, x.momentum());
-  if (x.is_generated_mass_set()) os << ", mass=" << x.data().mass;
-  os << ", pid=" << x.pid() << ", status=" << x.status() << ")";
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::GenVertex& x) {
-  os << "GenVertex(";
-  repr(os, x.position());
-  os << ")";
-  return os;
-}
-
-inline std::ostream& repr(std::ostream& os, const HepMC3::GenEvent& x) {
-  // incomplete:
-  // missing comparison of GenHeavyIon, GenPdfInfo, GenCrossSection
-
-  os << "GenEvent("
-     << "momentum_unit=" << x.momentum_unit() << ", "
-     << "length_unit=" << x.length_unit() << ", "
-     << "event_number=" << x.event_number() << ", "
-     << "particles=";
-  repr(os, x.particles()) << ", vertices=";
-  repr(os, x.vertices()) << ", run_info=";
-  repr(os, x.run_info()) << ")";
-  return os;
-}
+                       const std::vector<ConstGenVertexPtr>& b);
 
 int crosssection_safe_index(GenCrossSection& cs, py::object obj);
 std::string crosssection_safe_name(GenCrossSection& cs, py::object obj);
@@ -343,13 +135,8 @@ PYBIND11_MODULE(_core, m) {
       .def(py::self -= py::self)
       .def(py::self *= double())
       .def(py::self /= double())
-      .def("__repr__",
-           [](const FourVector& self) {
-             std::ostringstream os;
-             repr(os, self);
-             return os.str();
-           })
       // clang-format off
+      REPR(FourVector)
       METH(length2, FourVector)
       METH(length, FourVector)
       METH(perp2, FourVector)
@@ -603,14 +390,9 @@ PYBIND11_MODULE(_core, m) {
             }
           },
           DOC(attributes))
-      .def("__repr__",
-           [](const GenRunInfo& self) {
-             std::ostringstream os;
-             repr(os, self);
-             return os.str();
-           })
       .def(py::self == py::self)
       // clang-format off
+      REPR(GenRunInfo)
       PROP(weight_names, GenRunInfo)
       // clang-format on
       ;
@@ -624,14 +406,9 @@ PYBIND11_MODULE(_core, m) {
                                          py::cast<std::string>(seq[1]),
                                          py::cast<std::string>(seq[2])});
       }))
-      .def("__repr__",
-           [](const GenRunInfo::ToolInfo& self) {
-             std::ostringstream os;
-             repr(os, self);
-             return os.str();
-           })
       .def(py::self == py::self)
       // clang-format off
+      REPR(GenRunInfo::ToolInfo)
       ATTR(name, GenRunInfo::ToolInfo)
       ATTR(version, GenRunInfo::ToolInfo)
       ATTR(description, GenRunInfo::ToolInfo)
@@ -700,12 +477,6 @@ PYBIND11_MODULE(_core, m) {
       .def("reserve", &GenEvent::reserve, "particles"_a, "vertices"_a = 0,
            DOC(GenEvent.reserve))
       .def(py::self == py::self)
-      .def("__repr__",
-           [](GenEvent& self) {
-             std::ostringstream os;
-             repr(os, self);
-             return os.str();
-           })
       .def("__str__",
            [](GenEvent& self) {
              std::ostringstream os;
@@ -717,6 +488,7 @@ PYBIND11_MODULE(_core, m) {
            "children"_a = py::none(), "vx"_a = py::none(), "vy"_a = py::none(),
            "vz"_a = py::none(), "vt"_a = py::none(), DOC(GenEvent.from_hepevt))
       // clang-format off
+      REPR(GenEvent)
       METH(clear, GenEvent)
       PROP(run_info, GenEvent)
       PROP(event_number, GenEvent)
@@ -739,13 +511,6 @@ PYBIND11_MODULE(_core, m) {
   py::class_<GenParticle, GenParticlePtr>(m, "GenParticle", DOC(GenParticle))
       .def(py::init<const FourVector&, int, int>(),
            "momentum"_a = py::make_tuple(0, 0, 0, 0), "pid"_a = 0, "status"_a = 0)
-      .def(py::self == py::self)
-      .def("__repr__",
-           [](const GenParticlePtr& self) {
-             std::ostringstream os;
-             repr(os, self);
-             return os.str();
-           })
       .def_property(
           "attributes",
           [](GenParticle& self) {
@@ -760,7 +525,9 @@ PYBIND11_MODULE(_core, m) {
             }
           },
           DOC(attributes))
+      .def(py::self == py::self)
       // clang-format off
+      REPR(GenParticle)
       PROP_RO_OL(parent_event, GenParticle, const GenEvent*)
       PROP_RO(in_event, GenParticle)
       PROP_RO(id, GenParticle)
@@ -781,13 +548,6 @@ PYBIND11_MODULE(_core, m) {
 
   py::class_<GenVertex, GenVertexPtr>(m, "GenVertex", DOC(GenVertex))
       .def(py::init<const FourVector&>(), "position"_a = FourVector())
-      .def(py::self == py::self)
-      .def("__repr__",
-           [](const GenVertexPtr& self) {
-             std::ostringstream os;
-             repr(os, self);
-             return os.str();
-           })
       .def_property(
           "attributes",
           [](GenVertex& self) {
@@ -802,7 +562,9 @@ PYBIND11_MODULE(_core, m) {
             }
           },
           DOC(GenVertex.attributes))
+      .def(py::self == py::self)
       // clang-format off
+      REPR(GenParticle)
       PROP_RO_OL(parent_event, GenVertex, const GenEvent*)
       PROP_RO(in_event, GenVertex)
       PROP_RO(id, GenVertex)

--- a/src/equal.cpp
+++ b/src/equal.cpp
@@ -1,0 +1,124 @@
+#include "pointer.hpp"
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/GenHeavyIon.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/GenRunInfo.h>
+#include <HepMC3/GenVertex.h>
+
+namespace HepMC3 {
+
+template <class T>
+bool operator!=(const T& a, const T& b) {
+  return !operator==(a, b);
+}
+
+// equality comparions used by unit tests
+bool is_close(const FourVector& a, const FourVector& b, double rel_eps = 1e-7) {
+  auto is_close = [rel_eps](double a, double b) { return std::abs(a - b) < rel_eps; };
+  return is_close(a.x(), b.x()) && is_close(a.y(), b.y()) && is_close(a.z(), b.z()) &&
+         is_close(a.t(), b.t());
+}
+
+// compares all real qualities of two particles, but ignores the .id() field
+bool operator==(const GenParticle& a, const GenParticle& b) {
+  return a.pid() == b.pid() && a.status() == b.status() &&
+         is_close(a.momentum(), b.momentum());
+}
+
+// compares all real qualities of both particle sets,
+// but ignores the .id() fields and the particle order
+bool equal_particle_sets(const std::vector<ConstGenParticlePtr>& a,
+                         const std::vector<ConstGenParticlePtr>& b) {
+  if (a.size() != b.size()) return false;
+  auto unmatched = b;
+  for (auto&& ai : a) {
+    auto it = std::find_if(unmatched.begin(), unmatched.end(),
+                           [ai](ConstGenParticlePtr x) { return *ai == *x; });
+    if (it == unmatched.end()) return false;
+    unmatched.erase(it);
+  }
+  return unmatched.empty();
+}
+
+// compares all real qualities of two vertices, but ignores the .id() field
+bool operator==(const GenVertex& a, const GenVertex& b) {
+  return a.status() == b.status() && is_close(a.position(), b.position()) &&
+         equal_particle_sets(a.particles_in(), b.particles_in()) &&
+         equal_particle_sets(a.particles_out(), b.particles_out());
+}
+
+// compares all real qualities of both vertex sets,
+// but ignores the .id() fields and the vertex order
+bool equal_vertex_sets(const std::vector<ConstGenVertexPtr>& a,
+                       const std::vector<ConstGenVertexPtr>& b) {
+  if (a.size() != b.size()) return false;
+  auto unmatched = b;
+  for (auto&& ai : a) {
+    auto it = std::find_if(unmatched.begin(), unmatched.end(),
+                           [ai](ConstGenVertexPtr x) { return *ai == *x; });
+    if (it == unmatched.end()) return false;
+    unmatched.erase(it);
+  }
+  return unmatched.empty();
+}
+
+bool operator==(const GenRunInfo::ToolInfo& a, const GenRunInfo::ToolInfo& b) {
+  return a.name == b.name && a.version == b.version && a.description == b.description;
+}
+
+bool operator==(const GenRunInfo& a, const GenRunInfo& b) {
+  const auto a_attr = a.attributes();
+  const auto b_attr = b.attributes();
+  return a.tools().size() == b.tools().size() &&
+         a.weight_names().size() == b.weight_names().size() &&
+         a_attr.size() == b_attr.size() &&
+         std::equal(a.tools().begin(), a.tools().end(), b.tools().begin()) &&
+         std::equal(a.weight_names().begin(), a.weight_names().end(),
+                    b.weight_names().begin()) &&
+         std::equal(a_attr.begin(), a_attr.end(), b_attr.begin(),
+                    [](const std::pair<std::string, AttributePtr>& a,
+                       const std::pair<std::string, AttributePtr>& b) {
+                      if (a.first != b.first) return false;
+                      if (bool(a.second) != bool(b.second)) return false;
+                      if (!a.second) return true;
+                      std::string sa, sb;
+                      a.second->to_string(sa);
+                      b.second->to_string(sb);
+                      return sa == sb;
+                    });
+}
+
+bool operator==(const GenHeavyIon& a, const GenHeavyIon& b) {
+  return a.Ncoll_hard == b.Ncoll_hard && a.Npart_proj == b.Npart_proj &&
+         a.Npart_targ == b.Npart_targ && a.Ncoll == b.Ncoll &&
+         a.N_Nwounded_collisions == b.N_Nwounded_collisions &&
+         a.Nwounded_N_collisions == b.Nwounded_N_collisions &&
+         a.Nwounded_Nwounded_collisions == b.Nwounded_Nwounded_collisions &&
+         a.impact_parameter == b.impact_parameter &&
+         a.event_plane_angle == b.event_plane_angle &&
+         a.sigma_inel_NN == b.sigma_inel_NN && a.centrality == b.centrality &&
+         a.user_cent_estimate == b.user_cent_estimate;
+}
+
+bool operator==(const GenEvent& a, const GenEvent& b) {
+  // incomplete:
+  // missing comparison of GenHeavyIon, GenPdfInfo, GenCrossSection
+
+  if (a.event_number() != b.event_number() || a.momentum_unit() != b.momentum_unit() ||
+      a.length_unit() != b.length_unit())
+    return false;
+
+  // run_info may be missing
+  if (a.run_info() && b.run_info()) {
+    if (!(*a.run_info() == *b.run_info())) return false;
+  } else if (!a.run_info() && b.run_info()) {
+    if (*b.run_info() != GenRunInfo()) return false;
+  } else if (a.run_info() && !b.run_info()) {
+    if (*a.run_info() != GenRunInfo()) return false;
+  }
+
+  // if all vertices compare equal, then also all particles are equal
+  return equal_vertex_sets(a.vertices(), b.vertices());
+}
+
+} // namespace HepMC3

--- a/src/equal.cpp
+++ b/src/equal.cpp
@@ -1,3 +1,5 @@
+#include "HepMC3/GenPdfInfo.h"
+#include "HepMC3/LHEFAttributes.h"
 #include "pointer.hpp"
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/GenHeavyIon.h>
@@ -89,15 +91,38 @@ bool operator==(const GenRunInfo& a, const GenRunInfo& b) {
 }
 
 bool operator==(const GenHeavyIon& a, const GenHeavyIon& b) {
-  return a.Ncoll_hard == b.Ncoll_hard && a.Npart_proj == b.Npart_proj &&
-         a.Npart_targ == b.Npart_targ && a.Ncoll == b.Ncoll &&
-         a.N_Nwounded_collisions == b.N_Nwounded_collisions &&
-         a.Nwounded_N_collisions == b.Nwounded_N_collisions &&
-         a.Nwounded_Nwounded_collisions == b.Nwounded_Nwounded_collisions &&
-         a.impact_parameter == b.impact_parameter &&
-         a.event_plane_angle == b.event_plane_angle &&
-         a.sigma_inel_NN == b.sigma_inel_NN && a.centrality == b.centrality &&
-         a.user_cent_estimate == b.user_cent_estimate;
+  std::string as, bs;
+  a.to_string(as);
+  b.to_string(bs);
+  return as == bs;
+}
+
+bool operator==(const GenPdfInfo& a, const GenPdfInfo& b) {
+  std::string as, bs;
+  a.to_string(as);
+  b.to_string(bs);
+  return as == bs;
+}
+
+bool operator==(const GenCrossSection& a, const GenCrossSection& b) {
+  std::string as, bs;
+  a.to_string(as);
+  b.to_string(bs);
+  return as == bs;
+}
+
+bool operator==(const HEPRUPAttribute& a, const HEPRUPAttribute& b) {
+  std::string as, bs;
+  a.to_string(as);
+  b.to_string(bs);
+  return as == bs;
+}
+
+bool operator==(const HEPEUPAttribute& a, const HEPEUPAttribute& b) {
+  std::string as, bs;
+  a.to_string(as);
+  b.to_string(bs);
+  return as == bs;
 }
 
 bool operator==(const GenEvent& a, const GenEvent& b) {

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -1,4 +1,6 @@
+#include "UnparsedAttribute.hpp"
 #include "pybind.hpp"
+#include "repr.hpp"
 #include <HepMC3/GenRunInfo.h>
 #include <HepMC3/ReaderAscii.h>
 #include <HepMC3/ReaderAsciiHepMC2.h>
@@ -85,6 +87,14 @@ void register_io(py::module& m) {
   py::class_<WriterHEPEVT>(m, "WriterHEPEVT")
       .def(py::init<const std::string&>(), "filename"_a) METH(write_event, WriterHEPEVT)
           METH(failed, WriterHEPEVT) METH(close, WriterHEPEVT);
+
+  py::class_<UnparsedAttribute>(m, "UnparsedAttribute", DOC(UnparsedAttribute))
+      .def("__str__", [](UnparsedAttribute& a) { return a.parent_->unparsed_string(); })
+      // clang-format off
+      METH(astype, UnparsedAttribute, "pytype"_a)
+      REPR(UnparsedAttribute)
+      // clang-format on
+      ;
 
 #ifdef HEPMC3_ROOTIO
 

--- a/src/pointer.hpp
+++ b/src/pointer.hpp
@@ -1,6 +1,7 @@
 #ifndef PYHEPMC_POINTER_HPP
 #define PYHEPMC_POINTER_HPP
 
+#include "HepMC3/AssociatedParticle.h"
 #include "HepMC3/GenRunInfo.h"
 #include <memory>
 
@@ -10,13 +11,14 @@ class HEPEUPAttribute;
 class HEPRUPAttribute;
 class GenRunInfo;
 class GenEvent;
+class AssociatedParticle;
 
 using GenEventPtr = std::shared_ptr<GenEvent>;
 using AttributePtr = std::shared_ptr<Attribute>;
 using HEPEUPAttributePtr = std::shared_ptr<HEPEUPAttribute>;
 using HEPRUPAttributePtr = std::shared_ptr<HEPRUPAttribute>;
 using GenRunInfoPtr = std::shared_ptr<GenRunInfo>;
-using AttributePtr = std::shared_ptr<Attribute>;
+using AssociatedParticlePtr = std::shared_ptr<AssociatedParticle>;
 } // namespace HepMC3
 
 #endif

--- a/src/pybind.hpp
+++ b/src/pybind.hpp
@@ -17,27 +17,28 @@ _T overload_cast(_T x) {
   return x;
 }
 
-#define FUNC(name) m.def(#name, name, doc[#name].c_str())
-#define PROP_RO(name, cls) \
-  .def_property_readonly(#name, &cls::name, doc[#cls "." #name].c_str())
+#define DOC(name) doc[#name].c_str()
+
+#define FUNC(name) m.def(#name, name, DOC(name))
+#define PROP_RO(name, cls) .def_property_readonly(#name, &cls::name, DOC(cls.name))
 #define PROP_ROS(name, cls) \
-  .def_property_readonly_static(#name, &cls::name, doc[#cls "." #name].c_str())
+  .def_property_readonly_static(#name, &cls::name, DOC(cls.name))
 #define PROP_RO_OL(name, cls, rval)                                         \
   .def_property_readonly(#name, overload_cast<rval, const cls>(&cls::name), \
-                         doc[#cls "." #name].c_str())
+                         DOC(cls.name))
 #define PROP(name, cls) \
-  .def_property(#name, &cls::name, &cls::set_##name, doc[#cls "." #name].c_str())
+  .def_property(#name, &cls::name, &cls::set_##name, DOC(cls.name))
 #define PROP2(name, cls) \
-  .def_property(#name, &cls::get_##name, &cls::set_##name, doc[#cls "." #name].c_str())
+  .def_property(#name, &cls::get_##name, &cls::set_##name, DOC(cls.name))
 #define PROP_OL(name, cls, rval)                                                     \
   .def_property(#name, overload_cast<rval, const cls>(&cls::name), &cls::set_##name, \
-                doc[#cls "." #name].c_str())
-#define METH(name, cls) .def(#name, &cls::name, doc[#cls "." #name].c_str())
+                DOC(cls.name))
+#define METH(name, cls, ...) .def(#name, &cls::name, ##__VA_ARGS__, DOC(cls.name))
 #define METH_OL(name, cls, rval, args) \
-  .def(#name, (rval(cls::*)(args)) & cls::name, doc[#cls "." #name].c_str())
-#define ATTR(name, cls) .def_readwrite(#name, &cls::name, doc[#cls "." #name].c_str())
+  .def(#name, (rval(cls::*)(args)) & cls::name, DOC(cls.name))
+#define ATTR(name, cls) .def_readwrite(#name, &cls::name, DOC(cls.name))
 #define REPR(name) .def("__repr__", repr<name>)
-
-#define DOC(name) doc[#name].c_str()
+#define EQ(name) \
+  .def("__eq__", py::overload_cast<const name&, const name&>(HepMC3::operator==))
 
 #endif

--- a/src/pybind.hpp
+++ b/src/pybind.hpp
@@ -36,6 +36,7 @@ _T overload_cast(_T x) {
 #define METH_OL(name, cls, rval, args) \
   .def(#name, (rval(cls::*)(args)) & cls::name, doc[#cls "." #name].c_str())
 #define ATTR(name, cls) .def_readwrite(#name, &cls::name, doc[#cls "." #name].c_str())
+#define REPR(name) .def("__repr__", repr<name>)
 
 #define DOC(name) doc[#name].c_str()
 

--- a/src/pyhepmc/__init__.py
+++ b/src/pyhepmc/__init__.py
@@ -30,7 +30,7 @@ Missing functionality
 - Not yet implemented: ``GenParticleData``, ``GenVertexData``, ``ReaderMT``,
   ``ReaderGZ``, ``Setup``, ``WriterGZ``. These will be added in the future.
 """
-# flake8: F401
+from sys import version_info
 from ._core import (  # noqa: F401
     Units,
     FourVector,
@@ -96,6 +96,19 @@ try:
     GenEvent._repr_html_ = _genevent_repr_html
 except ModuleNotFoundError:
     pass
+
+
+if version_info >= (3, 8):
+    from typing import get_origin as _get_origin, get_args as _get_args
+else:
+
+    def _get_origin(pytype):  # type: ignore
+        if hasattr(pytype, "__origin__"):
+            return pytype.__origin__
+        return None
+
+    def _get_args(pytype):  # type: ignore
+        return pytype.__args__
 
 
 def __getattr__(name: str) -> _tp.Any:

--- a/src/pyhepmc/_doc.py
+++ b/src/pyhepmc/_doc.py
@@ -136,7 +136,10 @@ The units of cross-sections are expected to be pb.""",
     Parameters
     ----------
     pytype: type
-        The Python type of the attribute (int, float, bool, ...). Can also be typed list (typing.List[int], ...).
+        Type of the attribute. Allowed values: bool, int, float, str, GenParticle,
+        GenPdfInfo, GenHeavyIon, GenCrossSection, HEPRUPAttribute, HEPEUPAttribute,
+        typing.List[int], typing.List[float], typing.List[str]. In Python-3.9+,
+        typing.List can be replaced by list.
     """,
 }
 

--- a/src/pyhepmc/_doc.py
+++ b/src/pyhepmc/_doc.py
@@ -118,6 +118,26 @@ The units of cross-sections are expected to be pb.""",
 
     It is possible to read and write attributes. Primitive C++ types (and vectors therefore) are converted from/to native Python types.
     """,
+    "UnparsedAttribute": """Unparsed attribute after deserialization.
+
+    HepMC3 does not serialize the type of attributes, therefore the correct
+    type cannot be restored upon deserialization (this is a limition of the HepMC3 C++
+    library and its serialization format). Use the :meth:`astype` method to parse the
+    attribute into a concrete type; this has important side-effects, see method
+    description.
+    """,
+    "UnparsedAttribute.astype": """
+    Convert unparsed attribute to concrete type.
+
+    If the conversion is successful, the unparsed attribute is replaced with the parsed
+    attribute, so this method has to be called only once. If the conversion fails, a
+    TypeError is raised.
+
+    Parameters
+    ----------
+    pytype: type
+        The Python type of the attribute (int, float, bool, ...). Can also be typed list (typing.List[int], ...).
+    """,
 }
 
 doc.update(override)

--- a/src/pyhepmc/io.py
+++ b/src/pyhepmc/io.py
@@ -18,6 +18,7 @@ from ._core import (
     WriterAscii,
     WriterAsciiHepMC2,
     WriterHEPEVT,
+    UnparsedAttribute,
 )
 from pathlib import PurePath
 import typing as _tp
@@ -31,6 +32,7 @@ __all__ = [
     "WriterAscii",
     "WriterAsciiHepMC2",
     "WriterHEPEVT",
+    "UnparsedAttribute",
 ]
 
 _open = open

--- a/src/repr.cpp
+++ b/src/repr.cpp
@@ -1,0 +1,74 @@
+#include "repr.hpp"
+#include <HepMC3/Attribute.h>
+#include <HepMC3/FourVector.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/GenRunInfo.h>
+#include <HepMC3/GenVertex.h>
+#include <ostream>
+
+std::ostream& repr_ostream(std::ostream& os, const std::string& s) {
+  os << "'" << s << "'";
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::Attribute& a) {
+  std::string s;
+  a.to_string(s);
+  os << s;
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo::ToolInfo& x) {
+  os << "ToolInfo(name=";
+  repr_ostream(os, x.name) << ", version=";
+  repr_ostream(os, x.version) << ", description=";
+  repr_ostream(os, x.description) << ")";
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::FourVector& x) {
+  const int saved = os.precision();
+  os.precision(3);
+  os << "FourVector(" << x.x() << ", " << x.y() << ", " << x.z() << ", " << x.t()
+     << ")";
+  os.precision(saved);
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo& x) {
+  os << "GenRunInfo(tools=";
+  repr_ostream(os, x.tools()) << ", weight_names=";
+  repr_ostream(os, x.weight_names()) << ", attributes=";
+  repr_ostream(os, x.attributes()) << ")";
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenParticle& x) {
+  os << "GenParticle(";
+  repr_ostream(os, x.momentum());
+  if (x.is_generated_mass_set()) os << ", mass=" << x.data().mass;
+  os << ", pid=" << x.pid() << ", status=" << x.status() << ")";
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenVertex& x) {
+  os << "GenVertex(";
+  repr_ostream(os, x.position());
+  os << ")";
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenEvent& x) {
+  // incomplete:
+  // missing comparison of GenHeavyIon, GenPdfInfo, GenCrossSection
+
+  os << "GenEvent("
+     << "momentum_unit=" << x.momentum_unit() << ", "
+     << "length_unit=" << x.length_unit() << ", "
+     << "event_number=" << x.event_number() << ", "
+     << "particles=";
+  repr_ostream(os, x.particles()) << ", vertices=";
+  repr_ostream(os, x.vertices()) << ", run_info=";
+  repr_ostream(os, x.run_info()) << ")";
+  return os;
+}

--- a/src/repr.cpp
+++ b/src/repr.cpp
@@ -1,4 +1,5 @@
 #include "repr.hpp"
+#include "HepMC3/GenPdfInfo.h"
 #include <HepMC3/Attribute.h>
 #include <HepMC3/FourVector.h>
 #include <HepMC3/GenParticle.h>
@@ -15,6 +16,11 @@ std::ostream& repr_ostream(std::ostream& os, const HepMC3::Attribute& a) {
   std::string s;
   a.to_string(s);
   os << s;
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::UnparsedAttribute& a) {
+  os << "<UnparsedAttribute>('" << a.parent_->unparsed_string() << "')";
   return os;
 }
 
@@ -40,6 +46,15 @@ std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo& x) {
   repr_ostream(os, x.tools()) << ", weight_names=";
   repr_ostream(os, x.weight_names()) << ", attributes=";
   repr_ostream(os, x.attributes()) << ")";
+  return os;
+}
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenPdfInfo& x) {
+  os << "GenPdfInfo(";
+  os << "parton_id1=" << x.parton_id[0] << ", parton_id2=" << x.parton_id[1]
+     << ", x1=" << x.x[0] << ", x2=" << x.x[1] << ", scale=" << x.scale
+     << ", xf1=" << x.xf[0] << ", xf2=" << x.xf[1] << ", pdf_id1=" << x.pdf_id[0]
+     << ", pdf_id2=" << x.pdf_id[1] << ")";
   return os;
 }
 

--- a/src/repr.hpp
+++ b/src/repr.hpp
@@ -1,0 +1,75 @@
+#ifndef PYHEPMC_REPR_HPP
+#define PYHEPMC_REPR_HPP
+
+#include <HepMC3/Attribute.h>
+#include <HepMC3/FourVector.h>
+#include <HepMC3/GenCrossSection.h>
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/GenHeavyIon.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/GenPdfInfo.h>
+#include <HepMC3/GenRunInfo.h>
+#include <HepMC3/GenVertex.h>
+#include <HepMC3/LHEFAttributes.h>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <string>
+
+std::ostream& repr_ostream(std::ostream& os, const std::string& s);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::Attribute& a);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo& x);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo::ToolInfo& x);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::FourVector& x);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenParticle& x);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenVertex& x);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenEvent& x);
+
+template <class Iterator, class Streamer>
+std::ostream& ostream_range(std::ostream& os, Iterator begin, Iterator end,
+                            Streamer streamer, const char bracket_left = '[',
+                            const char bracket_right = ']') {
+  os << bracket_left;
+  bool first = true;
+  for (; begin != end; ++begin) {
+    if (first) {
+      first = false;
+    } else {
+      os << ", ";
+    }
+    streamer(os, begin);
+  }
+  os << bracket_right;
+  return os;
+}
+
+template <class T>
+std::ostream& repr_ostream(std::ostream& os, const std::shared_ptr<T>& x) {
+  if (x)
+    repr_ostream(os, *x.get());
+  else
+    os << "None";
+  return os;
+}
+
+template <class T, class A>
+std::ostream& repr_ostream(std::ostream& os, const std::vector<T, A>& v) {
+  return ostream_range(
+      os, v.begin(), v.end(),
+      [](std::ostream& os, typename std::vector<T, A>::const_iterator it) {
+        repr_ostream(os, *it);
+      });
+}
+
+template <class K, class V, class... Ts>
+std::ostream& repr_ostream(std::ostream& os, const std::map<K, V, Ts...>& m) {
+  return ostream_range(
+      os, m.begin(), m.end(),
+      [](std::ostream& os, typename std::map<K, V, Ts...>::const_iterator it) {
+        os << it->first << ": ";
+        repr_ostream(os, it->second);
+      },
+      '{', '}');
+}
+
+#endif

--- a/src/repr.hpp
+++ b/src/repr.hpp
@@ -1,6 +1,7 @@
 #ifndef PYHEPMC_REPR_HPP
 #define PYHEPMC_REPR_HPP
 
+#include "UnparsedAttribute.hpp"
 #include <HepMC3/Attribute.h>
 #include <HepMC3/FourVector.h>
 #include <HepMC3/GenCrossSection.h>
@@ -19,11 +20,14 @@
 std::ostream& repr_ostream(std::ostream& os, const std::string& s);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::Attribute& a);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo& x);
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenPdfInfo& x);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenRunInfo::ToolInfo& x);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::FourVector& x);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenParticle& x);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenVertex& x);
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenEvent& x);
+
+std::ostream& repr_ostream(std::ostream& os, const HepMC3::UnparsedAttribute& a);
 
 template <class Iterator, class Streamer>
 std::ostream& ostream_range(std::ostream& os, Iterator begin, Iterator end,
@@ -70,6 +74,13 @@ std::ostream& repr_ostream(std::ostream& os, const std::map<K, V, Ts...>& m) {
         repr_ostream(os, it->second);
       },
       '{', '}');
+}
+
+template <class T>
+py::str repr(const T& t) {
+  std::ostringstream os;
+  repr_ostream(os, t);
+  return py::cast(os.str());
 }
 
 #endif

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -105,6 +105,12 @@ def test_GenHeavyIon():
     assert hi != hep.GenHeavyIon()
 
 
+def test_GenParticle_as_attribute(evt):
+    p = evt.particles[3]
+    evt.attributes["foo"] = p
+    assert evt.attributes == {"foo": p}
+
+
 def test_GenCrossSection():
     cs = hep.GenCrossSection()
     cs.set_cross_section(1.2, 0.2, 3, 10)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,6 +6,7 @@ from test_basic import evt  # noqa
 from pyhepmc._core import stringstream
 from pathlib import Path
 import numpy as np
+import typing
 
 
 def test_read_write(evt):  # noqa
@@ -165,8 +166,8 @@ def test_attributes():
         "5": hep.GenHeavyIon(),
         "6": hep.GenCrossSection(),
         "7": p,
-        # "8": np.array([1, 2]),
-        # "9": np.array([1.3, 2.4]),
+        "8": [1, 2],
+        "9": [1.3, 2.4],
         # cannot test this yet
         # "8": hep.HEPRUPAttribute(),
         # "9": hep.HEPEUPAttribute(),
@@ -178,9 +179,22 @@ def test_attributes():
     with io.open(filename) as f:
         evt2 = f.read()
 
+    with pytest.raises(TypeError):
+        evt2.attributes["1"].astype(hep.GenPdfInfo)
+
+    with pytest.raises(TypeError, match="untyped list"):
+        evt2.attributes["8"].astype(list)
+
     for k, v in evt.attributes.items():
-        t = type(v)
+        if k == "8":
+            t = typing.List[int]
+        elif k == "9":
+            t = typing.List[float]
+        else:
+            t = type(v)
+
         v2 = evt2.attributes[k].astype(t)
+
         assert v == v2
         # UnparsedAttribute is replaced with parsed Attribute
         v3 = evt2.attributes[k]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -149,3 +149,41 @@ def test_open_with_writer(evt, writer):  # noqa
 def test_deprecated_import():
     with pytest.warns(np.VisibleDeprecationWarning):
         from pyhepmc import ReaderAscii  # noqa F401
+
+
+def test_attributes():
+    filename = "test_attributes.dat"
+
+    evt = hep.GenEvent()  # noqa
+    p = hep.GenParticle((1, 2, 3, 4), 5, 6)
+    evt.add_particle(p)
+    evt.attributes = {
+        "1": True,
+        "2": 2,
+        "3": 3.3,
+        "4": hep.GenPdfInfo(),
+        "5": hep.GenHeavyIon(),
+        "6": hep.GenCrossSection(),
+        "7": p,
+        # "8": np.array([1, 2]),
+        # "9": np.array([1.3, 2.4]),
+        # cannot test this yet
+        # "8": hep.HEPRUPAttribute(),
+        # "9": hep.HEPEUPAttribute(),
+    }
+
+    with io.open(filename, "w") as f:
+        f.write(evt)
+
+    with io.open(filename) as f:
+        evt2 = f.read()
+
+    for k, v in evt.attributes.items():
+        t = type(v)
+        v2 = evt2.attributes[k].astype(t)
+        assert v == v2
+        # UnparsedAttribute is replaced with parsed Attribute
+        v3 = evt2.attributes[k]
+        assert v == v3
+
+    os.unlink(filename)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -8,7 +8,6 @@ view = pytest.importorskip("pyhepmc.view")  # depends on graphviz and particle
 def test_dot(evt):  # noqa
     d = view.to_dot(evt)
     s = str(d)
-    print(s)
     assert s.startswith('digraph "dummy-1.0\nevent number = 1')
     assert "in_1" in s
     assert "in_2" in s


### PR DESCRIPTION
Allow assigning particles to attributes (via AssociatedParticle, but the Python code nevers sees this class).

Upon deserialization, unparsed attributes are now represented with the type UnparsedAttribute. Users can convert it to a real attribute with the astype method.