### PR TITLE
Support reuse of GenEvent in to_hepmc3 interface

### DIFF
--- a/src/pyhepmc/io.py
+++ b/src/pyhepmc/io.py
@@ -147,13 +147,15 @@ class _WrappedWriter:
     ):
         self._writer: _tp.Any = None
         self._init = (iostream, precision, Writer)
+        self._event = None
 
-    @staticmethod
-    def _maybe_convert(event: _tp.Any) -> GenEvent:
+    def _maybe_convert(self, event: _tp.Any) -> GenEvent:
         if isinstance(event, GenEvent):
             return event
         if hasattr(event, "to_hepmc3"):
-            return event.to_hepmc3()
+            # reuse GenEvent to not recreate GenRunInfo repeatedly
+            self._event = event.to_hepmc3(self._event)
+            return self._event
         raise TypeError(
             "event must be an instance of GenEvent or "
             "convertible to it by providing a to_hepmc3() method"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -218,10 +218,17 @@ def test_open_3(evt):  # noqa
             f.write("foo")
 
     class Foo:
-        def to_hepmc3(self):
-            return evt
+        def __init__(self, evt):
+            self.event = evt
+            self.run_info = evt.run_info
 
-    foo = Foo()
+        def to_hepmc3(self, event=None):
+            if event is None:
+                event = self.event
+            assert event.run_info is self.run_info
+            return event
+
+    foo = Foo(evt)
 
     with hep.open(filename, "w") as f:
         f.write(foo)


### PR DESCRIPTION
The optional `to_hepmc3` interface can be added to foreign event objects to support writing them as Hepmc files. This adds support for reuse of an existing GenEvent that was already converted. Clients can use this to add a GenRunInfo only once to the first event, which contains info that does not change during the run.