### PR TITLE
Pyiostream improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13...3.17)
 
+include(CMakePrintHelpers)
+
 find_program(ccache_executable ccache)
 if(ccache_executable)
   message(STATUS "Using ccache: ${ccache_executable}")
@@ -48,6 +50,8 @@ if(EXTERNAL_PYBIND11)
 else()
   add_subdirectory(extern/pybind11)
 endif()
+
+cmake_print_variables(CMAKE_BUILD_TYPE)
 
 file(GLOB SOURCES "src/*.cpp")
 file(GLOB HEPMC3_SOURCES "extern/HepMC3/src/*.cc")

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -36,6 +36,12 @@ void register_io(py::module& m) {
   auto doc = py::cast<std::map<std::string, std::string>>(m_doc.attr("doc"));
 
   py::class_<std::iostream>(m, "iostream")
+      .def("getline",
+           [](std::iostream& self) {
+             char buffer[1024];
+             self.getline(buffer, 1024);
+             return py::bytes(buffer);
+           })
       // clang-format off
       METH(flush, pyiostream)
       // clang-format on

--- a/src/pyhepmc/io.py
+++ b/src/pyhepmc/io.py
@@ -246,7 +246,7 @@ class HepMCFile:
                 if not self._file.seekable():
                     raise ValueError("cannot detect format is file is not seekable")
                 header = self._file.read(256)
-                assert isinstance(header, bytes)
+                assert isinstance(header, bytes)  # for mypy
                 self._file.seek(0)
                 if b"HepMC::Asciiv3" in header:
                     Reader = ReaderAscii

--- a/src/pyhepmc/io.py
+++ b/src/pyhepmc/io.py
@@ -244,7 +244,7 @@ class HepMCFile:
             if format is None:
                 # auto-detect
                 if not self._file.seekable():
-                    raise ValueError("cannot detect format is file is not seekable")
+                    raise ValueError("cannot detect format, file is not seekable")
                 header = self._file.read(256)
                 assert isinstance(header, bytes)  # for mypy
                 self._file.seek(0)
@@ -265,7 +265,7 @@ class HepMCFile:
                     "hepevt": ReaderHEPEVT,
                 }.get(format.lower(), None)
                 if Reader is None:
-                    raise ValueError(f"format {format} not recognized for reading")
+                    raise ValueError(f"format {format!r} not recognized for reading")
 
             self._reader = Reader(self._ios)
             self._writer = None
@@ -280,14 +280,14 @@ class HepMCFile:
                     "hepevt": WriterHEPEVT,
                 }.get(format.lower(), None)
                 if Writer is None:
-                    raise ValueError(f"format {format} not recognized for writing")
+                    raise ValueError(f"format {format!r} not recognized for writing")
 
             self._file = open(fn, mode)
             self._ios = pyiostream(self._file)
             self._reader = None
             self._writer = _WrappedWriter(self._ios, precision, Writer)
         else:
-            raise ValueError(f"mode must be 'r' or 'w', got {mode}")
+            raise ValueError(f"mode must be 'r' or 'w', got {mode!r}")
 
     def __enter__(self) -> HepMCFile:
         return self

--- a/src/pyiostream.hpp
+++ b/src/pyiostream.hpp
@@ -10,6 +10,7 @@ class pystreambuf : public std::streambuf {
   py::object iohandle_;
   py::object readinto_;
   py::object write_;
+  char search_for_cr_ = 0; // three-way 0 undecided, 1 yes, -1 no
   bool skip_next_ = false;
   char_type* end_ = nullptr;
 

--- a/src/pyiostream.hpp
+++ b/src/pyiostream.hpp
@@ -5,20 +5,15 @@
 #include <iostream>
 #include <streambuf>
 
-struct eol_normalizer {
-  bool skip_ = false;
-  void operator()(char* s, int& size) noexcept;
-};
-
 class pystreambuf : public std::streambuf {
   py::array_t<char_type> buffer_;
   py::object iohandle_;
   py::object readinto_;
   py::object write_;
-  eol_normalizer eol_normalizer_;
 
 public:
-  bool initialization_error() const { return !readinto_ || !write_; }
+  bool has_readinto() const { return !readinto_.is_none(); }
+  bool has_write() const { return !write_.is_none(); }
 
   pystreambuf(py::object iohandle, int size);
   pystreambuf(const pystreambuf&);

--- a/src/pyiostream.hpp
+++ b/src/pyiostream.hpp
@@ -10,6 +10,8 @@ class pystreambuf : public std::streambuf {
   py::object iohandle_;
   py::object readinto_;
   py::object write_;
+  bool skip_one_ = false;
+  char_type* true_end_ = nullptr;
 
 public:
   bool has_readinto() const { return !readinto_.is_none(); }

--- a/src/pyiostream.hpp
+++ b/src/pyiostream.hpp
@@ -10,8 +10,8 @@ class pystreambuf : public std::streambuf {
   py::object iohandle_;
   py::object readinto_;
   py::object write_;
-  bool skip_one_ = false;
-  char_type* true_end_ = nullptr;
+  bool skip_next_ = false;
+  char_type* end_ = nullptr;
 
 public:
   bool has_readinto() const { return !readinto_.is_none(); }

--- a/src/repr.cpp
+++ b/src/repr.cpp
@@ -20,7 +20,7 @@ std::ostream& repr_ostream(std::ostream& os, const HepMC3::Attribute& a) {
 }
 
 std::ostream& repr_ostream(std::ostream& os, const HepMC3::UnparsedAttribute& a) {
-  os << "<UnparsedAttribute>('" << a.parent_->unparsed_string() << "')";
+  os << "<UnparsedAttribute '" << a.parent_->unparsed_string() << "'>";
   return os;
 }
 
@@ -77,13 +77,13 @@ std::ostream& repr_ostream(std::ostream& os, const HepMC3::GenEvent& x) {
   // incomplete:
   // missing comparison of GenHeavyIon, GenPdfInfo, GenCrossSection
 
-  os << "GenEvent("
+  os << "<GenEvent "
      << "momentum_unit=" << x.momentum_unit() << ", "
      << "length_unit=" << x.length_unit() << ", "
      << "event_number=" << x.event_number() << ", "
-     << "particles=";
-  repr_ostream(os, x.particles()) << ", vertices=";
-  repr_ostream(os, x.vertices()) << ", run_info=";
-  repr_ostream(os, x.run_info()) << ")";
+     << "particles=" << x.particles().size() << ", "
+     << "vertices=" << x.vertices().size() << ", "
+     << "run_info=";
+  repr_ostream(os, x.run_info()) << ">";
   return os;
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -411,9 +411,8 @@ def test_sequence_access():
     assert evt.vertices[0].id == -1
     assert evt.vertices[0].position == (1, 2, 3, 4)
     assert repr(evt) == (
-        "GenEvent(momentum_unit=1, length_unit=0, event_number=0, "
-        "particles=[GenParticle(FourVector(1, 2, 3, 4), pid=5, status=0)], "
-        "vertices=[GenVertex(FourVector(1, 2, 3, 4))], run_info=None)"
+        "<GenEvent momentum_unit=1, length_unit=0, event_number=0, "
+        "particles=1, vertices=1, run_info=None>"
     )
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,6 +4,7 @@ import pyhepmc.io as io
 import pytest
 from test_basic import evt  # noqa
 from pyhepmc._core import stringstream, pyiostream
+from io import BytesIO
 from pathlib import Path
 import numpy as np
 import typing
@@ -67,6 +68,20 @@ def test_pystream_3(evt):  # noqa
     assert evt == evt2
 
     os.unlink(fn)
+
+
+@pytest.mark.parametrize("size", (100, 1))
+def test_pystream_4(size):
+    s = b"\r\n1\r\n\r\n22\r\n333\r\n"
+    io = BytesIO(s)
+    pio = pyiostream(io, size)
+    assert pio.getline() == b""
+    assert pio.getline() == b"1"
+    assert pio.getline() == b""
+    assert pio.getline() == b"22"
+    assert pio.getline() == b"333"
+    assert pio.getline() == b""
+    assert pio.getline() == b""
 
 
 def test_read_event_write_event(evt):  # noqa


### PR DESCRIPTION
Make pyiostream faster on Windows.

The HepMC3 code expects `\n` as linefeed character, even on Windows. To improve performance, we let Python read the raw bytestream and correct `\r\n` to `\n` in pyiostream, by manipulating the view on the internal buffer.

I previously used rewrite large parts of the internal buffer to perform this replacement, but now I manipulate only a few bytes and skip characters by manipulating the view. The new version should be faster.

**Other changes**
- GenEvent repr string is made more compact.