### PR TITLE
support stdin,stdout ; improved internal buffer 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,13 @@ on:
       - 'docs/**'
       - '*.rst'
       - '*.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.rst'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -42,6 +42,21 @@ void register_io(py::module& m) {
              self.getline(buffer, 1024);
              return py::bytes(buffer);
            })
+      .def("read",
+           [](std::iostream& self, int size) {
+             if (size > 1024) throw std::runtime_error("size must be <= 1024");
+             char buffer[1024];
+             self.read(buffer, size);
+             return py::bytes(buffer);
+           })
+      .def("write",
+           [](std::iostream& self, py::bytes s) {
+             char* buffer = nullptr;
+             py::ssize_t length = 0;
+             if (PYBIND11_BYTES_AS_STRING_AND_SIZE(s.ptr(), &buffer, &length))
+               py::pybind11_fail("Unable to extract bytes contents!");
+             self.write(buffer, length);
+           })
       // clang-format off
       METH(flush, pyiostream)
       // clang-format on

--- a/src/pyiostream.cpp
+++ b/src/pyiostream.cpp
@@ -113,7 +113,8 @@ void pystreambuf::pywrite_buffer() {
   assert(write_);
   const int s = std::distance(pbase(), pptr());
   py::gil_scoped_acquire g;
-  Py_SET_SIZE(buffer_.ptr(), s);
+  // Py_SET_SIZE(buffer_.ptr(), s); // use instead in CPython-3.9+
+  reinterpret_cast<PyVarObject*>(buffer_.ptr())->ob_size = s;
   PyByteArray_AS_STRING(buffer_.ptr())[s] = '\0'; /* Trailing null */
   write_(buffer_);
 }

--- a/src/pyiostream.cpp
+++ b/src/pyiostream.cpp
@@ -113,8 +113,8 @@ void pystreambuf::pywrite_buffer() {
   assert(write_);
   const int s = std::distance(pbase(), pptr());
   py::gil_scoped_acquire g;
+  Py_SIZE(buffer_.ptr()) = s;
   // Py_SET_SIZE(buffer_.ptr(), s); // use instead in CPython-3.9+
-  reinterpret_cast<PyVarObject*>(buffer_.ptr())->ob_size = s;
   PyByteArray_AS_STRING(buffer_.ptr())[s] = '\0'; /* Trailing null */
   write_(buffer_);
 }

--- a/src/pyiostream.cpp
+++ b/src/pyiostream.cpp
@@ -113,7 +113,7 @@ void pystreambuf::pywrite_buffer() {
   assert(write_);
   const int s = std::distance(pbase(), pptr());
   py::gil_scoped_acquire g;
-  Py_SIZE(buffer_.ptr()) = s;
+  reinterpret_cast<PyVarObject*>(buffer_.ptr())->ob_size = s;
   // Py_SET_SIZE(buffer_.ptr(), s); // use instead in CPython-3.9+
   PyByteArray_AS_STRING(buffer_.ptr())[s] = '\0'; /* Trailing null */
   write_(buffer_);

--- a/src/pyiostream.hpp
+++ b/src/pyiostream.hpp
@@ -6,7 +6,7 @@
 #include <streambuf>
 
 class pystreambuf : public std::streambuf {
-  py::array_t<char_type> buffer_;
+  py::bytearray buffer_;
   py::object iohandle_;
   py::object readinto_;
   py::object write_;

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -323,6 +323,19 @@ def test_open_6(evt, capsys):
     os.unlink(fn)
 
 
+def test_open_7():
+    import sys
+
+    fn = str(Path(__file__).parent / "sibyll21.dat")
+
+    with open(fn, "r") as f:
+        with hep.open(f, "r") as f2:
+            evt = f2.read()
+
+    assert len(evt.particles) == 23
+    assert len(evt.vertices) == 7
+
+
 def test_open_failures():
     fn = Path(__file__).parent / "pp.lhe"
     n = 0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -84,6 +84,14 @@ def test_pystream_4(size):
     assert pio.getline() == b""
 
 
+def test_pystream_5():
+    import sys
+
+    io = sys.stdout.buffer
+    with pyiostream(io, 100) as pio:
+        pio.write(b"foo")
+
+
 def test_read_event_write_event(evt):  # noqa
     oss = stringstream()
     with io.WriterAscii(oss) as f:
@@ -293,6 +301,26 @@ def test_open_5():
         for ev in f:
             n += 1
     assert n == 1
+
+
+def test_open_6(evt, capsys):
+    import sys
+
+    fn = "test_open_6.dat"
+
+    with hep.open(fn, "w") as f:
+        f.write(evt)
+
+    with open(fn, "rb") as f:
+        content = f.read().decode()
+
+    with hep.open(sys.stdout, "w") as f:
+        f.write(evt)
+
+    c = capsys.readouterr().out
+    assert c == content
+
+    os.unlink(fn)
 
 
 def test_open_failures():


### PR DESCRIPTION
Closes #50

pyhepmc.open now supports IO to file objects like stdin and stdout. The internal buffer handling is now fully efficient.

