### PR TITLE
Add Python 3.12

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [auto, aarch64, universal2]
-        py: [cp38, cp39, cp310, cp311]
+        py: [cp38, cp39, cp310, cp311, cp312]
         exclude:
           - os: windows-latest
             arch: aarch64


### PR DESCRIPTION
Release of chromo 0.4.2 https://github.com/impy-project/chromo/pull/196 adds Python 3.12 wheels. Because chromo relies on pyhepmc, wheels for pyhepmc on PyPI are needed.