### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           # version number must be string, otherwise 3.10 becomes 3.1
           - os: windows-latest
             python-version: "3.11"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.8"
           - os: ubuntu-latest
             python-version: "pypy-3.8"
@@ -44,5 +44,5 @@ jobs:
       env:
         DEBUG: 1
     - uses: ts-graphviz/setup-graphviz@v1
-      if: ${{ matrix.os != 'macos-latest' }}
+      if: ${{ matrix.os != 'macos-13' }}
     - run: python -m pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         arch: [auto, aarch64, universal2]
         py: [cp38, cp39, cp310, cp311, cp312]
         exclude:
@@ -30,7 +30,7 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: universal2
-          - os: macos-latest
+          - os: macos-13
             arch: aarch64
           - os: ubuntu-latest
             arch: universal2


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos