### PR TITLE
use py::overload_cast to make more robust

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -70,7 +70,7 @@ void register_io(py::module& m) {
       .def(py::init<>())
       .def(py::init<std::string>())
       .def("__str__",
-           (std::string(std::stringstream::*)() const)&std::stringstream::str);
+           py::overload_cast<>(&std::stringstream::str, py::const_));
 
   py::class_<Reader>(m, "Reader")
       // clang-format off

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -69,8 +69,7 @@ void register_io(py::module& m) {
   py::class_<std::stringstream, std::iostream>(m, "stringstream")
       .def(py::init<>())
       .def(py::init<std::string>())
-      .def("__str__",
-           py::overload_cast<>(&std::stringstream::str, py::const_));
+      .def("__str__", py::overload_cast<>(&std::stringstream::str, py::const_));
 
   py::class_<Reader>(m, "Reader")
       // clang-format off


### PR DESCRIPTION
This uses py::overload_cast to allow more robust cast which allows for differences in C++20 cast.